### PR TITLE
Es5/oops missed some

### DIFF
--- a/lib/alphabet.js
+++ b/lib/alphabet.js
@@ -128,11 +128,14 @@ function getPadding(alphabet) {
 
 function getAlphabet(alphabet) {
   if (!R.has(alphabet, cache)) {
-    const character62 = getCharacter62(alphabet);
-    const character63 = getCharacter63(alphabet);
-    const padding = getPadding(alphabet);
+    var character62 = getCharacter62(alphabet);
+    var character63 = getCharacter63(alphabet);
+    var padding     = getPadding(alphabet);
 
-    cache[alphabet] = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789${character62}${character63}${padding}`
+    cache[alphabet] = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                    + 'abcdefghijklmnopqrstuvwxyz'
+                    + '0123456789'
+                    + character62 + character63 + padding;
   }
 
   return R.prop(alphabet, cache);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-urlsafe-base64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A very simple base64 encoder that produces URL safe base64 encodings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- remove interpolated strings for es5 compatibility
- bump version to 1.1.2
